### PR TITLE
Adding "em" class to css

### DIFF
--- a/src/app/styles/customisations.scss
+++ b/src/app/styles/customisations.scss
@@ -103,3 +103,7 @@
   font-size: 14px;
   outline: none;
 }
+
+.sk-no-hits__em {
+  font-style: italic;
+}


### PR DESCRIPTION
Forgot to add "em" class to css.
For "Ничего не найдено для _{query}_. Искать:"