### PR TITLE
Adding "em" class to css

### DIFF
--- a/src/app/src/list-app/customisations.scss
+++ b/src/app/src/list-app/customisations.scss
@@ -102,3 +102,7 @@
   font-size: 14px;
   outline: none;
 }
+
+.sk-no-hits__em {
+  font-style: italic;
+}


### PR DESCRIPTION
Forgot to add "em" class to css.
For "Ничего не найдено для _{query}_. Искать:"